### PR TITLE
Load gatorc.bc.js as external

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
         <link rel="stylesheet" href="node_modules/codemirror/lib/codemirror.css">
 
-        <!-- <script src="/l/gatorc.bc.js"></script> -->
+        <script src="l/gatorc.bc.js"></script>
         <link rel = "stylesheet" type = "text/css" href = "./css/startpage.css" />
         <script language="JavaScript" type="text/javascript" src="./js/start_page.js"></script>
 

--- a/js/main.js
+++ b/js/main.js
@@ -5,8 +5,6 @@ import { Tutorial } from './tutorial.js';
 
 import mysql from 'mysql';
 
-//import { gator_ocaml } from "../l/gatorc.bc.js";
-
 var renderer = 0;
 var tutorial = 0;
 var currStep = 0;
@@ -16,7 +14,7 @@ var cm;
 
 
 
-// console.log(gator_ocaml.f("void main() {}"));
+console.log(gator.f("void main() {}"));
 
 function run() {
  // var vertSrc = document.getElementById("code_vert").value;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4304,6 +4304,16 @@
         "minimatch": "^3.0.4"
       }
     },
+    "parcel-plugin-static-files-copy": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/parcel-plugin-static-files-copy/-/parcel-plugin-static-files-copy-2.5.0.tgz",
+      "integrity": "sha512-5rxOPw3iV+WXhePfByoIxsUlL4I0o95CgcF31gwgnhPuj2q6tVPuzEAJsag9bWJr5Vd/SXFPTNsUAGAg4jP07Q==",
+      "dev": true,
+      "requires": {
+        "minimatch": "3.0.4",
+        "path": "0.12.7"
+      }
+    },
     "parse-asn1": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
@@ -4340,6 +4350,33 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+    },
+    "path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+      "dev": true,
+      "requires": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "util": {
+          "version": "0.10.4",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+          "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        }
+      }
     },
     "path-browserify": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,16 @@
     "python-shell": "^2.0.1"
   },
   "devDependencies": {
-    "parcel-plugin-html-externals": "^0.2.0"
+    "parcel-plugin-html-externals": "^0.2.0",
+    "parcel-plugin-static-files-copy": "^2.5.0"
   },
   "externals": {
-    "/l/gatorc.bc.js": false
+    "l/*": false
+  },
+  "staticFiles": {
+    "staticPath": [{
+      "staticPath": "l",
+      "staticOutDir": "l"
+    }]
   }
 }


### PR DESCRIPTION
This creates a global variable called `gator` that is accessible anywhere in any script. It works by (a) marking the `gatorc.bc.js` file as "external" so Parcel does not attempt to touch it, and (b) using a [second plugin][copy] to copy that file to the build directory.

I believe there is a second problem where `gator.f` expects a filename, not a source code string, but at least this works around the Parcel sadness.

[copy]: https://www.npmjs.com/package/parcel-plugin-static-files-copy
